### PR TITLE
error handling for visualizer tool

### DIFF
--- a/src/DependencyVisualizerTool/Program.cs
+++ b/src/DependencyVisualizerTool/Program.cs
@@ -1,19 +1,19 @@
 ﻿// See https://aka.ms/new-console-template for more information
 using System.CommandLine;
 
-var fileOption = new Option<FileInfo?>(
-            name: "--file",
-            description: "The file to read and display on the console.",
-            parseArgument: result =>
-            {
-                string? filePath = result.Tokens.Single().Value;
-                if (!File.Exists(filePath))
-                {
-                    result.ErrorMessage = "File does not exists";
-                    return null;
-                }
-                return new FileInfo(filePath);
-            });
+var fileArgument = new Argument<FileInfo?>(
+    name: "assetsFile",
+    description: "The file to read and display on the console.",
+    parse: result =>
+    {
+        string? filePath = result.Tokens.Single().Value;
+        if (!File.Exists(filePath))
+        {
+            result.ErrorMessage = "File does not exists";
+            return null;
+        }
+        return new FileInfo(filePath);
+    });
 
 var delayOption = new Option<int>(
     name: "--delay",
@@ -28,17 +28,18 @@ var rootCommand = new RootCommand("Dependency visualizer app for System.CommandL
 
 var readCommand = new Command("read", "Read and display the file.")
             {
-                fileOption,
                 delayOption,
                 lightModeOption
             };
-rootCommand.AddCommand(readCommand);
- 
+
+readCommand.AddArgument(fileArgument);
 readCommand.SetHandler(async (file, delay, lightMode) =>
 {
     await ReadFile(file!, delay, lightMode);
 },
-    fileOption, delayOption, lightModeOption);
+    fileArgument, delayOption, lightModeOption);
+
+rootCommand.AddCommand(readCommand);
 
 return rootCommand.InvokeAsync(args).Result;
 


### PR DESCRIPTION
Handled the exception that is thrown when the File to open and read is not found. Below is how the error is displayed now while it was just thrown earlier and was displaying the stacktrace
![image](https://user-images.githubusercontent.com/25676356/191374327-2d38de6e-7962-4388-88b0-2a319574bf50.png)
